### PR TITLE
error_in_core directive, for nightly-2024-02-17 Rust support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,7 @@ jobs:
     # TEST with Rust nightly back to July 2024 - TODO USE MATRIX FOR THIS
     - run: rustup default nightly-2024-07-01
     - run: cargo test --all-features
+    # TEST with Rust nightly back to late-February 2024 - TODO USE MATRIX FOR THIS
+    # (using --all-targets to avoid issues with doc tests on older Rust nightly versions)
+    - run: rustup default nightly-2024-02-17
+    - run: cargo test --all-features --all-targets

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 #![feature(ptr_as_uninit)]
 #![feature(slice_internals)]
 #![feature(specialization)]
+#![feature(error_in_core)]
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
DEFERRED TODO item: resolve known warning that is introduced with newer Rust nightly versions