### PR TITLE
more workarounds for Rust nightly -> 2022-08-24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,22 @@ jobs:
       run: cargo test --all-features --verbose
     # TODO: IMPROVE CONSISTENCY WITH STEPS ABOVE
     - run: cargo doc --all-features
-    # TEST with Rust nightly back to July 2024 - TODO USE MATRIX FOR THIS
-    - run: rustup default nightly-2024-07-01
-    - run: cargo test --all-features
-    # TEST with Rust nightly back to late-February 2024 - TODO USE MATRIX FOR THIS
-    # (using --all-targets to avoid issues with doc tests on older Rust nightly versions)
+    # TODO: USE MATRIX FOR TESTING WITH OTHER RUST NIGHTLY VERSIONS
+    - run: git clean -dfX # QUICK WORKAROUND to remove Cargo lock file version 4
+    # (NEED TO USE `--all-targets` to avoid issues with doc tests on some older Rust nightly versions below)
+    # TEST with MSRV (nightly)
+    - run: rustup default nightly-2022-08-24
+    - run: cargo test --all-features --all-targets
+    # TEST with Rust nightly from mid-2023
+    - run: rustup default nightly-2023-07-01
+    - run: cargo test --all-features --all-targets
+    # TEST with Rust nightly from late-February 2024 to check for correct rustversion conditions
     - run: rustup default nightly-2024-02-17
     - run: cargo test --all-features --all-targets
+    - run: rustup default nightly-2024-02-16
+    - run: cargo test --all-features --all-targets
+    - run: rustup default nightly-2024-02-15
+    - run: cargo test --all-features --all-targets
+    # TEST with a more recent Rust nightly version (no need for --all-targets)
+    - run: rustup default nightly-2024-07-01
+    - run: cargo test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ A subset of Rust `std::io` functionality supported for `no-std`.
 
 [dependencies]
 libc = { version = "0.2.169", default-features = false }
+rustversion = "1.0.19"
 
 [features]
 # TODO: finer-grained feature options

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A subset of Rust `std::io` functionality supported for `no-std`.
 
 ## requirements
 
-- Rust nightly toolchain since: `nightly-2024-02-17`
+- Rust nightly toolchain - MSRV: `nightly-2022-08-24`
 - enable `--cfg portable_io_unstable_all` Rust flag
 - enable `alloc` feature
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 #![feature(slice_internals)]
 #![feature(specialization)]
 #![feature(error_in_core)]
+#![feature(mixed_integer_ops)]
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
- use `rustversion` to cope with `MaybeUninit` fn that was renamed in February 2024
- add feature directive: `#![feature(mixed_integer_ops)]`

TODO items deferred for now:
- replace kludgy CI updates with proper CI matrix
- resolve new warning that is now expected with recent Rust nightly versions

---

__TODO ITEM(s):__

- [x] ~~resolve XXX items in these updates~~
- [x] ~~update MSRV in README.md~~