### PR TITLE
fix non-Unix support with generic sys::io::IoSlice structs (etc.)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup default ${{ matrix.rust }}
-      # TODO: SEPARATE BUILD JOB, CHECK FOR NO BUILD WARNINGS
+      # TODO: MOVE CARGO BUILD TEST TO NEW BUILD JOB & CHECK FOR ANY BUILD WARNINGS TO BE RESOLVED
       - run: cargo build --all-features ${{ matrix.test-options }} --verbose
         if: (!startsWith(matrix.os, 'windows'))
       - run: cargo test --all-features ${{ matrix.test-options }} --verbose
         if: (!startsWith(matrix.os, 'windows'))
+      # TODO: MOVE WINDOWS CARGO BUILD TEST TO NEW BUILD JOB & CHECK FOR ANY BUILD WARNINGS TO BE RESOLVED
+      - run: cargo build --features alloc ${{ matrix.test-options }} --verbose
+        if: startsWith(matrix.os, 'windows')
       - run: cargo test --features alloc ${{ matrix.test-options }} --verbose
 
   doc:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         if: (!startsWith(matrix.os, 'windows'))
       - run: cargo test --all-features ${{ matrix.test-options }} --verbose
         if: (!startsWith(matrix.os, 'windows'))
-      # TODO: MOVE WINDOWS CARGO BUILD TEST TO NEW BUILD JOB & CHECK FOR ANY BUILD WARNINGS TO BE RESOLVED
+      # TODO: MOVE CARGO BUILD TEST TO NEW BUILD JOB & CHECK FOR ANY BUILD WARNINGS TO BE RESOLVED
       - run: cargo build --features alloc ${{ matrix.test-options }} --verbose
       - run: cargo test --features alloc ${{ matrix.test-options }} --verbose
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,9 @@ jobs:
       - run: rustup default ${{ matrix.rust }}
       # TODO: MOVE CARGO BUILD TEST TO NEW BUILD JOB & CHECK FOR ANY BUILD WARNINGS TO BE RESOLVED
       - run: cargo build --all-features ${{ matrix.test-options }} --verbose
-        if: !startsWith(matrix.os, 'windows')
+        if: (!startsWith(matrix.os, 'windows'))
       - run: cargo test --all-features ${{ matrix.test-options }} --verbose
-        if: !startsWith(matrix.os, 'windows')
+        if: (!startsWith(matrix.os, 'windows'))
       # TODO: MOVE WINDOWS CARGO BUILD TEST TO NEW BUILD JOB & CHECK FOR ANY BUILD WARNINGS TO BE RESOLVED
       - run: cargo build --features alloc ${{ matrix.test-options }} --verbose
       - run: cargo test --features alloc ${{ matrix.test-options }} --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,13 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup default ${{ matrix.rust }}
       # TODO: MOVE CARGO BUILD TEST TO NEW BUILD JOB & CHECK FOR ANY BUILD WARNINGS TO BE RESOLVED
+      - run: cargo build --features alloc ${{ matrix.test-options }} --verbose
+      - run: cargo test --features alloc ${{ matrix.test-options }} --verbose
+      # TODO: MOVE CARGO BUILD TEST TO NEW BUILD JOB & CHECK FOR ANY BUILD WARNINGS TO BE RESOLVED
       - run: cargo build --all-features ${{ matrix.test-options }} --verbose
         if: (!startsWith(matrix.os, 'windows'))
       - run: cargo test --all-features ${{ matrix.test-options }} --verbose
         if: (!startsWith(matrix.os, 'windows'))
-      # TODO: MOVE CARGO BUILD TEST TO NEW BUILD JOB & CHECK FOR ANY BUILD WARNINGS TO BE RESOLVED
-      - run: cargo build --features alloc ${{ matrix.test-options }} --verbose
-      - run: cargo test --features alloc ${{ matrix.test-options }} --verbose
 
   doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
         if: (!startsWith(matrix.os, 'windows'))
       # TODO: MOVE WINDOWS CARGO BUILD TEST TO NEW BUILD JOB & CHECK FOR ANY BUILD WARNINGS TO BE RESOLVED
       - run: cargo build --features alloc ${{ matrix.test-options }} --verbose
-        if: startsWith(matrix.os, 'windows')
       - run: cargo test --features alloc ${{ matrix.test-options }} --verbose
 
   doc:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,9 @@ jobs:
       - run: rustup default ${{ matrix.rust }}
       # TODO: MOVE CARGO BUILD TEST TO NEW BUILD JOB & CHECK FOR ANY BUILD WARNINGS TO BE RESOLVED
       - run: cargo build --all-features ${{ matrix.test-options }} --verbose
-        if: (!startsWith(matrix.os, 'windows'))
+        if: !startsWith(matrix.os, 'windows')
       - run: cargo test --all-features ${{ matrix.test-options }} --verbose
-        if: (!startsWith(matrix.os, 'windows'))
+        if: !startsWith(matrix.os, 'windows')
       # TODO: MOVE WINDOWS CARGO BUILD TEST TO NEW BUILD JOB & CHECK FOR ANY BUILD WARNINGS TO BE RESOLVED
       - run: cargo build --features alloc ${{ matrix.test-options }} --verbose
       - run: cargo test --features alloc ${{ matrix.test-options }} --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,8 @@ jobs:
           - rust: nightly
           - os: macos-latest
             rust: nightly
-          # TODO: RESOLVE KNOWN BUILD FAILURE ON WINDOWS
-          # - os: windows-latest
-          #   ...
+          - os: windows-latest
+            rust: nightly
           - rust: nightly-2024-07-01
           - rust: nightly-2023-07-01
             test-options: --all-targets # SKIP doc tests
@@ -43,7 +42,9 @@ jobs:
       - run: rustup default ${{ matrix.rust }}
       # TODO: SEPARATE BUILD JOB, CHECK FOR NO BUILD WARNINGS
       - run: cargo build --all-features ${{ matrix.test-options }} --verbose
+        if: (!startsWith(matrix.os, 'windows'))
       - run: cargo test --all-features ${{ matrix.test-options }} --verbose
+        if: (!startsWith(matrix.os, 'windows'))
       - run: cargo test --features alloc ${{ matrix.test-options }} --verbose
 
   doc:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ A subset of Rust `std::io` functionality supported for `no-std`.
 """
 
 [dependencies]
+# XXX TODO libc OPTIONAL
 libc = { version = "0.2.169", default-features = false }
 rustversion = "1.0.19"
 
@@ -17,3 +18,5 @@ rustversion = "1.0.19"
 alloc = []
 # TODO DOCUMENT AS UNSTABLE FEATURE with some MISSING FUNCTIONALITY (with known panics)
 os-error = []
+# XXX TODO XXX libc
+unix-iovec = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,13 @@ A subset of Rust `std::io` functionality supported for `no-std`.
 """
 
 [dependencies]
-# XXX TODO libc OPTIONAL
-libc = { version = "0.2.169", default-features = false }
+libc = { version = "0.2.169", optional = true, default-features = false }
 rustversion = "1.0.19"
 
 [features]
 # TODO: finer-grained feature options
 alloc = []
-# TODO DOCUMENT AS UNSTABLE FEATURE with some MISSING FUNCTIONALITY (with known panics)
+# TODO: DOCUMENT AS UNSTABLE FEATURE with some MISSING FUNCTIONALITY (with known panics)
 os-error = []
-# XXX TODO XXX libc
-unix-iovec = []
+# TODO: DOCUMENT AS UNSTABLE FEATURE FOR UNIX PLATFORMS ONLY
+unix-iovec = ["dep:libc"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,9 @@ compile_error!("`alloc` feature is currently required for this library to build"
 #[cfg(not(any(doc,portable_io_unstable_all)))]
 compile_error!("`--cfg portable_io_unstable_all` Rust flag is currently required for this library to build");
 
+#[cfg(all(feature = "unix-iovec", not(unix)))]
+compile_error!("`unix-iovec` feature requires a Unix platform");
+
 struct Guard<'a> {
     buf: &'a mut Vec<u8>,
     len: usize,

--- a/src/sys/io_default.rs
+++ b/src/sys/io_default.rs
@@ -1,0 +1,50 @@
+// based on:
+// - https://github.com/rust-lang/rust/blob/1.59.0/library/std/src/sys/unsupported/io.rs
+
+use core::mem;
+
+#[derive(Copy, Clone)]
+pub struct IoSlice<'a>(&'a [u8]);
+
+impl<'a> IoSlice<'a> {
+    #[inline]
+    pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
+        IoSlice(buf)
+    }
+
+    #[inline]
+    pub fn advance(&mut self, n: usize) {
+        self.0 = &self.0[n..]
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        self.0
+    }
+}
+
+pub struct IoSliceMut<'a>(&'a mut [u8]);
+
+impl<'a> IoSliceMut<'a> {
+    #[inline]
+    pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
+        IoSliceMut(buf)
+    }
+
+    #[inline]
+    pub fn advance(&mut self, n: usize) {
+        let slice = mem::replace(&mut self.0, &mut []);
+        let (_, remaining) = slice.split_at_mut(n);
+        self.0 = remaining;
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        self.0
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.0
+    }
+}

--- a/src/sys/io_unix_iovec.rs
+++ b/src/sys/io_unix_iovec.rs
@@ -1,3 +1,6 @@
+// based on:
+// - https://github.com/rust-lang/rust/blob/1.59.0/library/std/src/sys/unix/io.rs
+
 use core::marker::PhantomData;
 use core::slice;
 

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -1,3 +1,11 @@
-// TODO EXPECTED TO BREAK ON NON-UNIX PLATFORMS
-// adaptation of UNIX types & helpers as needed
-pub(crate) mod io;
+pub(crate) mod io_default;
+#[cfg(feature = "unix-iovec")]
+mod io_unix_iovec;
+
+pub(crate) mod io {
+    #[cfg(not(feature = "unix-iovec"))]
+    pub(crate) use super::io_default::*;
+
+    #[cfg(feature = "unix-iovec")]
+    pub(crate) use super::io_unix_iovec::*;
+}


### PR DESCRIPTION
- adapt module from: https://github.com/rust-lang/rust/blob/1.59.0/library/std/src/sys/unsupported/io.rs
- add unstable `unix-iovec` to gate implementation working with `libc::iovec` on Unix
- update CI to test on Windows
- other minor updates

---

__TODO item(s):__

- [x] ~~resolve XXX items in `Cargo.toml`~~
- [x] ~~add CI `cargo build` testing on Windows~~
- ~~add CI `cargo build` testing on one more non-Unix platform~~ - _deferred, may try adding `no-std` support with CI build testing in the future_
- [x] ~~check for any other XXX items in these updates~~
- ~~rebase with cleaner commit message before merging~~ - _did squash merge with updated commit info from above_