### PR TITLE
cleanup: cargo fmt updates; add fmt CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup default ${{ matrix.rust }}
+      - run: rustup component add rustfmt
       - run: cargo fmt --check
 
   doc:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
   # General TODO items:
   # - try Rust clippy (should avoid all warnings)
   # - check for build & test warnings
-  # - enforce consistent Rust fmt (if possible without affecting too much code)
   test:
     strategy:
       matrix:
@@ -48,6 +47,22 @@ jobs:
         if: (!startsWith(matrix.os, 'windows'))
       - run: cargo test --all-features ${{ matrix.test-options }} --verbose
         if: (!startsWith(matrix.os, 'windows'))
+
+  fmt:
+    strategy:
+      # XXX TBD ??? ???
+      fail-fast: false
+      matrix:
+        include:
+          # XXX TBD ??? ???
+          - rust: stable
+          - rust: nightly
+          - rust: nightly-2025-01-01
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup default ${{ matrix.rust }}
+      - run: cargo fmt --check
 
   doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,4 +69,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup default nightly
+      - run: rustup component add rustfmt
       - run: cargo doc --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,5 +69,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup default nightly
-      - run: rustup component add rustfmt
       - run: cargo doc --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,14 +73,11 @@ jobs:
 
   fmt:
     strategy:
-      # XXX TBD ??? ???
       fail-fast: false
       matrix:
         include:
-          # XXX TBD ??? ???
           - rust: stable
           - rust: nightly
-          - rust: nightly-2025-01-01
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,10 @@
+# XXX TODO TRY TO MODERNIZE THIS FOR 2025
+# based on:
+# - https://github.com/rust-lang/rust/blob/1.59.0/rustfmt.toml
+#
+# TODO: UPDATE rustfmt config to work with updated Rust toolchain without affecting formatting of code from Rust `std`
+#
+# Run rustfmt with this config (it should be picked up automatically).
+version = "Two"
+use_small_heuristics = "Max"
+merge_derives = false

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,10 +1,10 @@
-# XXX TODO TRY TO MODERNIZE THIS FOR 2025
 # based on:
 # - https://github.com/rust-lang/rust/blob/1.59.0/rustfmt.toml
+# - https://github.com/rust-lang/rust/blob/1.83.0/rustfmt.toml
 #
-# TODO: UPDATE rustfmt config to work with updated Rust toolchain without affecting formatting of code from Rust `std`
+# NOTE: stable toolchain seems to display a warning message while formatting with this config.
 #
 # Run rustfmt with this config (it should be picked up automatically).
-version = "Two"
+style_edition = "2024"
 use_small_heuristics = "Max"
 merge_derives = false

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -9,7 +9,8 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use crate::{
-    self as io, BufRead, Error, ErrorKind, IoSlice, IoSliceMut, Read, ReadBuf, Seek, SeekFrom, Write,
+    self as io, BufRead, Error, ErrorKind, IoSlice, IoSliceMut, Read, ReadBuf, Seek, SeekFrom,
+    Write,
 };
 
 // =============================================================================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 //! <!-- TODO INCLUDE & ADAPT MORE DOC COMMENTS HERE -->
 
 #![no_std]
-
 #![feature(allocator_api)]
 #![feature(doc_notable_trait)]
 #![feature(maybe_uninit_slice)]
@@ -45,12 +44,14 @@ mod readbuf;
 mod sys;
 
 // TODO: support limited features with no use of `alloc` crate
-#[cfg(not(any(doc,feature = "alloc")))]
+#[cfg(not(any(doc, feature = "alloc")))]
 compile_error!("`alloc` feature is currently required for this library to build");
 
 // TODO: finer-grained unstable features
-#[cfg(not(any(doc,portable_io_unstable_all)))]
-compile_error!("`--cfg portable_io_unstable_all` Rust flag is currently required for this library to build");
+#[cfg(not(any(doc, portable_io_unstable_all)))]
+compile_error!(
+    "`--cfg portable_io_unstable_all` Rust flag is currently required for this library to build"
+);
 
 #[cfg(all(feature = "unix-iovec", not(unix)))]
 compile_error!("`unix-iovec` feature requires a Unix platform");
@@ -1168,7 +1169,7 @@ pub enum SeekFrom {
     ///
     /// It is possible to seek beyond the end of an object, but it's an error to
     /// seek before byte 0.
-    Current(i64)
+    Current(i64),
 }
 
 fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>) -> Result<usize> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //! <!-- TODO INCLUDE & ADAPT MORE DOC COMMENTS HERE -->
 
 #![no_std]
+// ---
 #![feature(allocator_api)]
 #![feature(doc_notable_trait)]
 #![feature(min_specialization)]

--- a/src/readbuf.rs
+++ b/src/readbuf.rs
@@ -102,7 +102,8 @@ impl<'a> ReadBuf<'a> {
     pub fn initialized_mut(&mut self) -> &mut [u8] {
         //SAFETY: We only slice the initialized part of the buffer, which is always valid
         // (ADAPTED to avoid using unstable fn)
-        let initialized_slice_mut_ptr = &mut self.buf[0..self.initialized] as *mut [MaybeUninit<u8>];
+        let initialized_slice_mut_ptr =
+            &mut self.buf[0..self.initialized] as *mut [MaybeUninit<u8>];
         unsafe { &mut *(initialized_slice_mut_ptr as *mut [u8]) }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,10 +5,10 @@ use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 
-use crate::{Cursor, ReadBuf, SeekFrom};
 use crate::cmp::{self, min};
 use crate::{self as io, IoSlice, IoSliceMut};
 use crate::{BufRead, Read, Seek, Write};
+use crate::{Cursor, ReadBuf, SeekFrom};
 
 #[test]
 #[cfg_attr(target_os = "emscripten", ignore)]


### PR DESCRIPTION
__DESCRIPTION:__

- add `rustfmt.toml` to maintain code formatting without affecting code coming from from Rust `std` library
- update code as required by using `cargo fmt` to pass `cargo fmt --check`
- add `fmt` CI job
- add separator comment after `no_std` directive in `src/lib.rs`

---

__TODO ITEM(S):__

- [x] ~~modernize fmt config for 2025 (if possible without affecting code from Rust `std` library)~~
- [x] ~~resolve XXX / TODO items in these updates~~