### PR TITLE
refactor: avoid using some unstable Rust features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,6 @@ jobs:
             test-options: --all-targets # SKIP doc tests
           - rust: nightly-2022-08-24 # MSRV (nightly)
             test-options: --all-targets # SKIP doc tests
-          # TEST with these Rust nightly versions to check for correct rustversion conditions in `src/readbuf.rs`
-          - rust: nightly-2024-02-17
-            test-options: --all-targets # SKIP doc tests
-          - rust: nightly-2024-02-16
-            test-options: --all-targets # SKIP doc tests
-          - rust: nightly-2024-02-15
-            test-options: --all-targets # SKIP doc tests
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ A subset of Rust `std::io` functionality supported for `no-std`.
 [dependencies]
 libc = { version = "0.2.169", optional = true, default-features = false }
 memchr = { version = "2.7.4", default-features = false }
-rustversion = "1.0.19"
 
 [features]
 # TODO: finer-grained feature options

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ A subset of Rust `std::io` functionality supported for `no-std`.
 
 [dependencies]
 libc = { version = "0.2.169", optional = true, default-features = false }
+memchr = { version = "2.7.4", default-features = false }
 rustversion = "1.0.19"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,7 @@
 
 #![feature(allocator_api)]
 #![feature(doc_notable_trait)]
-#![feature(maybe_uninit_slice)]
-#![feature(maybe_uninit_write_slice)]
-#![feature(ptr_as_uninit)]
-#![feature(slice_internals)]
-#![feature(specialization)]
+#![feature(min_specialization)]
 #![feature(error_in_core)]
 #![feature(mixed_integer_ops)]
 
@@ -23,7 +19,6 @@ use core::fmt;
 use core::mem::replace;
 use core::ops::{Deref, DerefMut};
 use core::slice;
-use core::slice::memchr;
 use core::str;
 
 extern crate alloc;

--- a/src/readbuf.rs
+++ b/src/readbuf.rs
@@ -40,13 +40,8 @@ impl<'a> ReadBuf<'a> {
     #[inline]
     pub fn new(buf: &'a mut [u8]) -> ReadBuf<'a> {
         let len = buf.len();
-
         // FOR ADAPTED code below
         let buf_ptr = buf as *mut [u8];
-        // XXX TODO NEEDS RATIONALE & UNIT TEST
-        if buf_ptr.is_null() {
-            panic!("XXX");
-        }
 
         ReadBuf {
             //SAFETY: initialized data never becoming uninitialized is an invariant of ReadBuf

--- a/src/readbuf.rs
+++ b/src/readbuf.rs
@@ -4,6 +4,7 @@ mod tests;
 use core::cmp;
 use core::fmt::{self, Debug, Formatter};
 use core::mem::MaybeUninit;
+use core::slice;
 
 /// A wrapper around a byte buffer that is incrementally filled and initialized.
 ///
@@ -40,9 +41,17 @@ impl<'a> ReadBuf<'a> {
     pub fn new(buf: &'a mut [u8]) -> ReadBuf<'a> {
         let len = buf.len();
 
+        // FOR ADAPTED code below
+        let buf_ptr = buf as *mut [u8];
+        // XXX TODO NEEDS RATIONALE & UNIT TEST
+        if buf_ptr.is_null() {
+            panic!("XXX");
+        }
+
         ReadBuf {
             //SAFETY: initialized data never becoming uninitialized is an invariant of ReadBuf
-            buf: unsafe { (buf as *mut [u8]).as_uninit_slice_mut().unwrap() },
+            // (ADAPTED to avoid using unstable fn)
+            buf: unsafe { slice::from_raw_parts_mut(buf_ptr as *mut MaybeUninit<u8>, len) },
             filled: 0,
             initialized: len,
         }
@@ -66,14 +75,18 @@ impl<'a> ReadBuf<'a> {
     #[inline]
     pub fn filled(&self) -> &[u8] {
         //SAFETY: We only slice the filled part of the buffer, which is always valid
-        unsafe { MaybeUninit::slice_assume_init_ref(&self.buf[0..self.filled]) }
+        // (ADAPTED to avoid using unstable fn)
+        let filled_slice_ptr = &self.buf[0..self.filled] as *const [MaybeUninit<u8>];
+        unsafe { &*(filled_slice_ptr as *const [u8]) }
     }
 
     /// Returns a mutable reference to the filled portion of the buffer.
     #[inline]
     pub fn filled_mut(&mut self) -> &mut [u8] {
         //SAFETY: We only slice the filled part of the buffer, which is always valid
-        unsafe { MaybeUninit::slice_assume_init_mut(&mut self.buf[0..self.filled]) }
+        // (ADAPTED to avoid using unstable fn)
+        let filled_slice_mut_ptr = &mut self.buf[0..self.filled] as *mut [MaybeUninit<u8>];
+        unsafe { &mut *(filled_slice_mut_ptr as *mut [u8]) }
     }
 
     /// Returns a shared reference to the initialized portion of the buffer.
@@ -82,7 +95,9 @@ impl<'a> ReadBuf<'a> {
     #[inline]
     pub fn initialized(&self) -> &[u8] {
         //SAFETY: We only slice the initialized part of the buffer, which is always valid
-        unsafe { MaybeUninit::slice_assume_init_ref(&self.buf[0..self.initialized]) }
+        // (ADAPTED to avoid using unstable fn)
+        let initialized_slice_ptr = &self.buf[0..self.initialized] as *const [MaybeUninit<u8>];
+        unsafe { &*(initialized_slice_ptr as *const [u8]) }
     }
 
     /// Returns a mutable reference to the initialized portion of the buffer.
@@ -91,7 +106,9 @@ impl<'a> ReadBuf<'a> {
     #[inline]
     pub fn initialized_mut(&mut self) -> &mut [u8] {
         //SAFETY: We only slice the initialized part of the buffer, which is always valid
-        unsafe { MaybeUninit::slice_assume_init_mut(&mut self.buf[0..self.initialized]) }
+        // (ADAPTED to avoid using unstable fn)
+        let initialized_slice_mut_ptr = &mut self.buf[0..self.initialized] as *mut [MaybeUninit<u8>];
+        unsafe { &mut *(initialized_slice_mut_ptr as *mut [u8]) }
     }
 
     /// Returns a mutable reference to the unfilled part of the buffer without ensuring that it has been fully
@@ -221,8 +238,9 @@ impl<'a> ReadBuf<'a> {
 
         // SAFETY: we do not de-initialize any of the elements of the slice
         unsafe {
-            // ADAPTED with WORKAROUND fn to support Rust nightly -> 2022-08-24
-            write_unfilled_buf(self, buf);
+            // (ADAPTED to avoid using unstable fn)
+            let buf_as_slice = &*(buf as *const [u8] as *const [MaybeUninit<u8>]);
+            self.unfilled_mut()[..buf.len()].copy_from_slice(buf_as_slice);
         };
 
         // SAFETY: We just added the entire contents of buf to the filled section.
@@ -241,16 +259,4 @@ impl<'a> ReadBuf<'a> {
     pub fn initialized_len(&self) -> usize {
         self.initialized
     }
-}
-
-// WORKAROUND fn to support Rust nightly -> 2022-08-24
-#[rustversion::since(2024-02-16)]
-#[inline]
-unsafe fn write_unfilled_buf(this: &mut ReadBuf, buf: &[u8]) {
-    MaybeUninit::copy_from_slice(&mut this.unfilled_mut()[..buf.len()], buf);
-}
-#[rustversion::before(2024-02-16)]
-#[inline]
-unsafe fn write_unfilled_buf(this: &mut ReadBuf, buf: &[u8]) {
-    MaybeUninit::write_slice(&mut this.unfilled_mut()[..buf.len()], buf);
 }


### PR DESCRIPTION
## DESCRIPTION

- use external `memchr` via `dependencies` instead of internal `core::slice::memchr` crate
- adapt multiple functions in `src/readbuf.rs` to avoid using unstable functions from Rust library
- remove `rustversion` from `dependencies` (no longer needed)
- remove CI testing with Rust nightly versions from February 2024, no longer needed now that `rustversion` conditions are removed from `src/readbuf.rs`
- remove feature directives not needed from `src/lib.rs`
- use `min_specialization` instead of `specialization` feature directive in `src/lib.rs`

---

## RATIONALE

This should help build most of this library with Rust stable, as started in PR #17

---

## TODO ITEM(S)

- [ ] resolve XXX / TODO item(s) in `src/readbuf.rs`
- [ ] check for any other XXX / TODO items in these updates