### PR TITLE
cleanup: move `dependencies` section in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,6 @@ description = """"
 A subset of Rust `std::io` functionality supported for `no-std`.
 """
 
-[dependencies]
-libc = { version = "0.2.169", optional = true, default-features = false }
-memchr = { version = "2.7.4", default-features = false }
-
 [features]
 # TODO: finer-grained feature options
 alloc = []
@@ -19,6 +15,10 @@ alloc = []
 os-error = []
 # TODO: DOCUMENT AS UNSTABLE FEATURE FOR UNIX PLATFORMS ONLY
 unix-iovec = ["dep:libc"]
+
+[dependencies]
+libc = { version = "0.2.169", optional = true, default-features = false }
+memchr = { version = "2.7.4", default-features = false }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [


### PR DESCRIPTION
RATIONALE: `features` section should come first, as this is more important info for anyone examining this package and is more consistent with `portable-atomic` & `tokio` packages