### PR TITLE
update Rust edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "portable-io"
 version = "0.0.3-dev"
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/brodycj/portable-io"
 description = """"


### PR DESCRIPTION
__STATUS:__ I think this kind of update is good practice. My only doubt is if there may be any interest in supporting any older Rust versions, which may be possible by not deriving from core Error trait. Keeping this at low priority for now.

---

__UPDATE:__ I went ahead and merged this update. I figure it should be no problem to revert in case of any need to support any older Rust versions.