### PR TITLE
support `impl Write for Vec` without custom allocator

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ pre-`2024-06-09` to enable `error_in_core` feature directive (stabilized in June
 
 ## CFG options
 
-- `portable_io_unstable_all` - enable all unstable options:
-  - impl Write for Vec - uses Rust unstable `allocator_api` feature
+- `portable_io_unstable_all` - enable all unstable option(s):
   - size hint optimization for Read iterator - uses Rust unstable `min_specialization` feature
 
 To enable: use `--cfg portable_io_unstable_all` in Rust flags, set `RUSTFLAGS` env variable

--- a/src/cursor/tests.rs
+++ b/src/cursor/tests.rs
@@ -5,7 +5,6 @@ use alloc::vec::Vec;
 use crate::prelude::*;
 use crate::{Cursor, IoSlice, IoSliceMut, SeekFrom};
 
-#[cfg(portable_io_unstable_all)] // for unstable feature: impl Write for Vec
 #[test]
 fn test_vec_writer() {
     let mut writer = Vec::new();

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,5 +1,3 @@
-#[cfg(portable_io_unstable_all)] // for unstable feature: impl Write for Vec
-use core::alloc::Allocator;
 use core::cmp;
 use core::fmt;
 use core::mem;
@@ -368,10 +366,8 @@ impl Write for &mut [u8] {
 /// Write is implemented for `Vec<u8>` by appending to the vector.
 /// The vector will grow as needed.
 ///
-/// <!-- TODO: use Rust (nightly) doc_cfg feature to document feature & cfg option requirements (if possible) -->
-/// <div class="warning">REQUIRES Rust CFG flag: <code>portable_io_unstable_all</code></div>
-#[cfg(portable_io_unstable_all)] // unstable feature: impl Write for Vec (requires Rust nightly for allocator_api)
-impl<A: Allocator> Write for Vec<u8, A> {
+/// NOTE: Unlike `std::io`, this does not support `Write` for `Vec` with a custom allocator.
+impl Write for Vec<u8> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.extend_from_slice(buf);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,7 @@
 //!
 //! ## CFG options
 //!
-//! - `portable_io_unstable_all` - enable all unstable options:
-//!   - impl Write for Vec - uses Rust unstable `allocator_api` feature
+//! - `portable_io_unstable_all` - enable all unstable option(s):
 //!   - size hint optimization for Read iterator - uses Rust unstable `min_specialization` feature
 //!
 //! To enable: use `--cfg portable_io_unstable_all` in Rust flags, set `RUSTFLAGS` env variable


### PR DESCRIPTION
When I tried using `portable-io` in `rustls`, `tokio`, and `futures-io`, these all require `Write` to be implemented for `Vec<u8>`, but no requirement for supporting a custom allocator.

This is a proposal to support `impl Write for Vec` with no CFG condition, without support for the custom allocator API.

I think it should be no problem to add an option to support `impl Write for Vec` with a custom allocator, if needed at some point.